### PR TITLE
ad wildcard * to cors config, so that netlify preview deployments can…

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'http://localhost:3000', 'https://dreamy-dubinsky-916568.netlify.app'
+    origins 'http://localhost:3000', '*dreamy-dubinsky-916568.netlify.app'
 
     resource '*',
       headers: :any,


### PR DESCRIPTION
… be used